### PR TITLE
Dot notation snake case allowed

### DIFF
--- a/nodeStyleGuide/.eslintrc
+++ b/nodeStyleGuide/.eslintrc
@@ -43,7 +43,7 @@
          // Use Operators before line starts.
         "operator-linebreak": [
             2, 
-            "before"
+            "after"
         ],
         // No TODO, FIXME.
         "no-warning-comments": [
@@ -56,10 +56,10 @@
                     "location": "anywhere" 
             }
         ],
-        // Max nested callbacks 2.
+        // Max nested callbacks 3.
         "max-nested-callbacks": [
             2, 
-            2
+            3
         ],
         // First argument of callback should be err.
         "handle-callback-err": [
@@ -104,7 +104,11 @@
         "strict": [
             2,
             "global"
-        ]
+        ],
+        no-underscore-dangle: [
+            0
+        ],
+        no-shadow: 0
     },
     "ecmaFeatures": {
         "jsx": true

--- a/nodeStyleGuide/.eslintrc
+++ b/nodeStyleGuide/.eslintrc
@@ -25,7 +25,7 @@
          "camelcase": [
             2, 
             {
-                "properties": "always"
+                "properties": "never"
             }
          ],
          // Capture nested context of this in self


### PR DESCRIPTION
Variables inside objects allows snake-case. It is enabled because third party lib use snake case and lint throws error in not enabled.
